### PR TITLE
12 months not 13 months Cost Explorer lookback

### DIFF
--- a/doc_source/usage-reports.md
+++ b/doc_source/usage-reports.md
@@ -1,6 +1,6 @@
 # Amazon EC2 usage reports<a name="usage-reports"></a>
 
-AWS provides a free reporting tool called AWS Cost Explorer that enables you to analyze the cost and usage of your EC2 instances and the usage of your Reserved Instances\. You can view data up to the last 13 months, and forecast how much you are likely to spend for the next three months\. You can use Cost Explorer to see patterns in how much you spend on AWS resources over time, identify areas that need further inquiry, and see trends that you can use to understand your costs\. You also can specify time ranges for the data, and view time data by day or by month\.
+AWS provides a free reporting tool called AWS Cost Explorer that enables you to analyze the cost and usage of your EC2 instances and the usage of your Reserved Instances\. You can view data up to the last 12 months, and forecast how much you are likely to spend for the next three months\. You can use Cost Explorer to see patterns in how much you spend on AWS resources over time, identify areas that need further inquiry, and see trends that you can use to understand your costs\. You also can specify time ranges for the data, and view time data by day or by month\.
 
 Here's an example of some of the questions that you can answer when using Cost Explorer:
 + How much am I spending on instances of each instance type?


### PR DESCRIPTION
12 months, not 13. See your Cost Explorer for your maximum date range (365 days maximum).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
